### PR TITLE
Docker support and documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+node_modules/
+.github/
+.git/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@ Dockerfile
 node_modules/
 .github/
 .git/
+docker-compose.yml
+README.md

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Node.js CI
 
 on:
@@ -16,8 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -25,6 +21,5 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm run build --if-present
-    - run: npm test
+    - run: pnpm install
+    - run: pnpm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:lts
+ENV NODE_ENV=production
+WORKDIR /app
+
+RUN npm install -g typescript && corepack enable
+
+COPY ["package.json", "pnpm-lock.yaml", "./"]
+
+RUN pnpm install
+
+COPY . .
+
+RUN pnpm run build
+
+CMD ["pnpm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-green.svg"></a>
   <a href="https://www.typescriptlang.org"><img src="https://img.shields.io/badge/TypeScript-%23007ACC.svg?logo=typescript&logoColor=white"></a>
-  <a href="https://github.com/herzhenr/spic-server/releases"><img src="https://img.shields.io/github/release/herzhenr/spic-server.svg?logo=github&color=blue"></a>
+  <a href="https://github.com/neferin12/matrix-studrss-bot/actions/workflows/node.js.yml"><img src="https://github.com/neferin12/matrix-studrss-bot/actions/workflows/node.js.yml/badge.svg?branch=main"></a>
+  <a href="https://github.com/herzhenr/spic-server/releases"><img src="https://img.shields.io/github/release/neferin12/matrix-studrss-bot.svg?logo=github&color=blue"></a>
 </p>
 
 A bot that reads news from the Studon RSS feed and sends them to a Matrix chat.
@@ -18,6 +19,9 @@ The following commands are available for the Bot:
 # Installation
 
 The environment variables `ACCESS_TOKEN` and `HOMESERVER_URL` must be set.
+
+- `HOMESERVER_URL`: The url of the matrix server
+- `ACCESS_TOKEN`: The access token of the matrix user which the bot should use. Do not use the access token of your account as this would lead to the bot replying in your name to every message you recieve!
 
 ## Docker
 
@@ -54,7 +58,7 @@ ACCESS_TOKEN=SECRET
 
 ## Local
 
-`TypeScript` and `pnpm` as the package manager must be installed. The server can be strated with:
+`TypeScript` and `pnpm` as the package manager must be installed. The server can be started with:
 
 ```bash
 pnpm install

--- a/README.md
+++ b/README.md
@@ -1,3 +1,87 @@
-# matrix-studrss-bot
+# Matrix Studrss Bot
 
-Documentation in work
+<p align="center">
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-green.svg"></a>
+  <a href="https://www.typescriptlang.org"><img src="https://img.shields.io/badge/TypeScript-%23007ACC.svg?logo=typescript&logoColor=white"></a>
+  <a href="https://github.com/herzhenr/spic-server/releases"><img src="https://img.shields.io/github/release/herzhenr/spic-server.svg?logo=github&color=blue"></a>
+</p>
+
+A bot that reads news from the Studon RSS feed and sends them to a Matrix chat.
+
+# Usage
+The following commands are available for the Bot:
+- `help`: Shows a help dialog with the available commands
+- `status`: Gives information about the current status
+- `set URL_OF_STUDON_RSS_FEED`: Sets the URL and activates bridging
+- `reset`: Deletes the URL and deactivates bridging
+
+# Installation
+
+The environment variables `ACCESS_TOKEN` and `HOMESERVER_URL` must be set.
+
+## Docker
+
+The easiest way to get started is by spinning up the docker container which can be obtained from the GitHub Container Registry. Then the following command can be run:
+
+```bash
+docker run --rm -it matrixstudrssbot:latest \
+-e ACCESS_TOKEN='token' \
+-e HOMESERVER_URL='url'
+```
+
+Alternatively the following [`docker-compose.yaml`](./docker-compose.yaml) can be used:
+
+```yml
+---
+version: "3"
+services:
+  matrix-studrss-bot:
+    image: matrixstudrssbot:latest
+    container_name: matrixstudrssbot
+    env_file:
+      - .env
+    environment:
+      HOMESERVER_URL: URL
+      ACCESS_TOKEN: ${ACCESS_TOKEN}
+    restart: unless-stopped
+```
+corresponding `.env` file:
+```
+ACCESS_TOKEN=SECRET
+```
+
+
+
+## Local
+
+`TypeScript` and `pnpm` as the package manager must be installed. The server can be strated with:
+
+```bash
+pnpm install
+pnpm run build
+```
+
+# License
+MIT License
+
+```
+Copyright (c) 2023
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: "3.5"
+services:
+  matrix-studrss-bot:
+    image: matrixstudrssbot:latest
+    container_name: matrixstudrssbot
+    environment:
+      - ACCESS_TOKEN=TODO
+      - HOMESERVER_URL=TODO
+    restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "matrix-studrss",
   "version": "1.1.0",
   "description": "Ein Bot, der aus dem Studon RSS Feed liest und die Nachrichten in einen Matrix Chat schickt",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "scripts": {
     "test": "eslint .",
-    "build": "npx tsc -p tsconfig.json",
-    "start": "node dist/index.js",
+    "build": "tsc -p tsconfig.json",
+    "start": "node .",
     "serve": "nodemon",
     "serve:2": "ts-node src/index.ts"
   },

--- a/src/matrix/Client.ts
+++ b/src/matrix/Client.ts
@@ -24,6 +24,8 @@ class Client {
 
         const storage = new SimpleFsStorageProvider("bot.json");
         const {ACCESS_TOKEN, HOMESERVER_URL} = process.env;
+        if(!ACCESS_TOKEN) throw new Error("No access token provided");
+        if(!HOMESERVER_URL) throw new Error("No homeserver URL provided");
         this.client = new MatrixClient(HOMESERVER_URL, ACCESS_TOKEN, storage);
         AutojoinRoomsMixin.setupOnClient(this.client);
 


### PR DESCRIPTION
- added support for Docker: `Dockerfile` added for building the container
  - automatic upload of the image to the GitHub Container Registry and DockerHub is missing for now, this will be implemented in the future in a separate GitHub Actions workflow
- extended documentation
  - added `README` and a example `docker-compose.yml` file for spinning up the container
- added `MIT License` note
- better error handling if the  `.env` variables `ACCESS_TOKEN ` or `HOMESERVER_URL ` are not set